### PR TITLE
Fix UTC date bug: use local time for all date strings

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,11 @@
 import { Plugin, WorkspaceLeaf } from "obsidian";
-import { AbacusData, AbacusSettings, DailyRecord, DEFAULT_DATA, DEFAULT_SETTINGS } from "./types";
+import { AbacusData, AbacusSettings, DailyRecord, DEFAULT_DATA, DEFAULT_SETTINGS, localDateStr } from "./types";
 import { AbacusSettingTab } from "./settings";
 import { AbacusStatsView, VIEW_TYPE_ABACUS_STATS } from "./stats-view";
 import { EditorView, ViewUpdate } from "@codemirror/view";
 
 function getToday(): string {
-	return new Date().toISOString().slice(0, 10);
+	return localDateStr(new Date());
 }
 
 function countWords(text: string): number {
@@ -17,7 +17,7 @@ function countWords(text: string): number {
 function daysAgo(days: number): string {
 	const d = new Date();
 	d.setDate(d.getDate() - days);
-	return d.toISOString().slice(0, 10);
+	return localDateStr(d);
 }
 
 export default class AbacusPlugin extends Plugin {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,6 @@
 import { App, PluginSettingTab, Setting } from "obsidian";
 import AbacusPlugin from "./main";
+import { localDateStr } from "./types";
 
 export class AbacusSettingTab extends PluginSettingTab {
 	plugin: AbacusPlugin;
@@ -53,7 +54,7 @@ export class AbacusSettingTab extends PluginSettingTab {
 			.setDesc("Clear today's word count back to zero.")
 			.addButton((button) =>
 				button.setButtonText("Reset").onClick(async () => {
-					const today = new Date().toISOString().slice(0, 10);
+					const today = localDateStr(new Date());
 					this.plugin.data.increments = this.plugin.data.increments.filter((i) => i.date !== today);
 					delete this.plugin.data.compacted[today];
 					await this.plugin.saveAbacusData();

--- a/src/stats-view.ts
+++ b/src/stats-view.ts
@@ -1,6 +1,6 @@
 import { ItemView, WorkspaceLeaf } from "obsidian";
 import AbacusPlugin from "./main";
-import { DailyRecord } from "./types";
+import { DailyRecord, localDateStr } from "./types";
 
 export const VIEW_TYPE_ABACUS_STATS = "abacus-stats-view";
 
@@ -40,7 +40,7 @@ export class AbacusStatsView extends ItemView {
 		const goal = this.plugin.data.settings.dailyGoal;
 
 		// Today summary
-		const today = new Date().toISOString().slice(0, 10);
+		const today = localDateStr(new Date());
 		const todayRecord = records[today];
 		const net = todayRecord?.netWords ?? 0;
 		const added = todayRecord?.wordsAdded ?? 0;

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,3 +34,8 @@ export const DEFAULT_DATA: AbacusData = {
 	increments: [],
 	compacted: {},
 };
+
+/** Format a Date as YYYY-MM-DD in local time. */
+export function localDateStr(d: Date): string {
+	return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}


### PR DESCRIPTION
## Summary
- Extracted a shared `localDateStr()` helper that formats dates as YYYY-MM-DD in local time
- Replaced all 4 instances of `toISOString().slice(0, 10)` across `main.ts`, `stats-view.ts`, and `settings.ts`
- Fixes words being attributed to the wrong day when typing near midnight

Fixes #1

## Test plan
- [ ] Verify status bar shows correct date attribution
- [ ] Verify history table dates match local time
- [ ] Confirm reset-today command targets the correct local date

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, mechanical change limited to date-string formatting; primary risk is minor behavioral change in how existing data gets attributed around timezone boundaries.
> 
> **Overview**
> Switches all date-key generation from UTC (`toISOString().slice(0, 10)`) to a shared `localDateStr()` helper so word increments, “today” summaries, and reset-today actions align with the user’s local day (fixing near-midnight misattribution).
> 
> Adds `localDateStr()` in `types.ts` and updates `main.ts`, `stats-view.ts`, and `settings.ts` to use it for `today` and “days ago” calculations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd34e5378bff519717d4b94e8c2f14b287bf3422. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->