### PR TITLE
Debounce stats view refresh

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -24,6 +24,7 @@ export default class AbacusPlugin extends Plugin {
 	data: AbacusData;
 	statusBarEl: HTMLElement;
 	private saveTimeout: ReturnType<typeof setTimeout> | null = null;
+	private refreshTimeout: ReturnType<typeof setTimeout> | null = null;
 
 	async onload() {
 		await this.loadAbacusData();
@@ -78,6 +79,9 @@ export default class AbacusPlugin extends Plugin {
 			clearTimeout(this.saveTimeout);
 			this.saveAbacusData();
 		}
+		if (this.refreshTimeout) {
+			clearTimeout(this.refreshTimeout);
+		}
 	}
 
 	handleDocChange(update: ViewUpdate) {
@@ -99,7 +103,7 @@ export default class AbacusPlugin extends Plugin {
 
 		this.debounceSave();
 		this.updateStatusBar();
-		this.refreshStatsView();
+		this.debounceRefreshStatsView();
 	}
 
 	/**
@@ -241,10 +245,14 @@ export default class AbacusPlugin extends Plugin {
 		}
 	}
 
-	/**
-	 * Debounce saves to avoid writing on every keystroke.
-	 * Flushes after 2 seconds of inactivity.
-	 */
+	private debounceRefreshStatsView() {
+		if (this.refreshTimeout) clearTimeout(this.refreshTimeout);
+		this.refreshTimeout = setTimeout(() => {
+			this.refreshTimeout = null;
+			this.refreshStatsView();
+		}, 2000);
+	}
+
 	private debounceSave() {
 		if (this.saveTimeout) clearTimeout(this.saveTimeout);
 		this.saveTimeout = setTimeout(() => {


### PR DESCRIPTION
## Summary
- Stats sidebar now only refreshes after 2 seconds of typing inactivity
- Status bar updates remain immediate (cheap `setText` call)
- Refresh timeout is cleaned up on plugin unload

Fixes #2

## Test plan
- [ ] Type quickly and verify sidebar doesn't visibly flicker/rebuild
- [ ] Stop typing and confirm sidebar updates after ~2s
- [ ] Status bar still updates in real-time

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI/performance change limited to view refresh timing; minimal risk aside from slightly delayed stats updates.
> 
> **Overview**
> Debounces stats sidebar updates by replacing per-keystroke `refreshStatsView()` calls with a 2s `debounceRefreshStatsView()` timer, while leaving status bar updates immediate.
> 
> Adds `refreshTimeout` state and clears it on plugin unload to avoid a pending refresh running after teardown.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92bcdc270db488c8547adcbbabd9ec559fc6bb03. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->