### PR TITLE
Clean up stale dailyRecords key and show year on old dates

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -258,6 +258,9 @@ export default class AbacusPlugin extends Plugin {
 					}
 				}
 			}
+			// Remove stale key and persist
+			delete (this.data as unknown as Record<string, unknown>)["dailyRecords"];
+			await this.saveAbacusData();
 		}
 	}
 

--- a/src/stats-view.ts
+++ b/src/stats-view.ts
@@ -127,9 +127,11 @@ export class AbacusStatsView extends ItemView {
 	}
 
 	private formatDate(dateStr: string): string {
-		const [_year, month, day] = dateStr.split("-");
+		const [year, month, day] = dateStr.split("-");
 		const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
-		return `${months[parseInt(month!, 10) - 1]} ${parseInt(day!, 10)}`;
+		const currentYear = String(new Date().getFullYear());
+		const base = `${months[parseInt(month!, 10) - 1]} ${parseInt(day!, 10)}`;
+		return year === currentYear ? base : `${base}, ${year}`;
 	}
 
 	private renderBarChart(container: HTMLElement, records: DailyRecord[]) {


### PR DESCRIPTION
## Summary
- After migrating from the old `dailyRecords` format, the stale key is now deleted from `data.json` and saved
- History dates now show the year for entries not in the current year (e.g. "Feb 19, 2025" vs "Feb 19")

Fixes #4, fixes #5

## Test plan
- [ ] Verify `dailyRecords` key is removed from data.json after reload
- [ ] Verify current-year dates show as "Feb 23"
- [ ] Verify older dates would show as "Feb 23, 2025"

🤖 Generated with [Claude Code](https://claude.com/claude-code)