### PR TITLE
Add manual compact button to settings

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,4 +1,4 @@
-import { App, PluginSettingTab, Setting } from "obsidian";
+import { App, Notice, PluginSettingTab, Setting } from "obsidian";
 import AbacusPlugin from "./main";
 import { localDateStr } from "./types";
 
@@ -47,6 +47,15 @@ export class AbacusSettingTab extends PluginSettingTab {
 							await this.plugin.saveAbacusData();
 						}
 					})
+			)
+			.addButton((button) =>
+				button.setButtonText("Compact now").onClick(() => {
+					const before = this.plugin.data.increments.length;
+					this.plugin.compact(localDateStr(new Date()));
+					const after = this.plugin.data.increments.length;
+					const compacted = before - after;
+					new Notice(`Abacus: compacted ${compacted} increment${compacted === 1 ? "" : "s"}`);
+				})
 			);
 
 		new Setting(containerEl)


### PR DESCRIPTION
## Summary
- Adds a "Compact now" button inline with the compaction threshold setting
- Runs the existing `compact()` method on demand
- Shows a notice with how many increments were compacted

Fixes #8

## Test plan
- [ ] Verify button appears next to the compaction threshold text input
- [ ] Click button and verify notice shows correct count
- [ ] Verify data.json is updated after compaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)